### PR TITLE
Fix the readme to change 777 to +x

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Make sure the uncompressed files are under the directory  /home/USER_NAME/data/a
 	cd
 	git clone https://github.com/astar-ai/aslam.git
 	cd aslam
-	chmod 777 ./link
+	chmod +x ./link
 	./link
 
 ### 5. Run


### PR DESCRIPTION
The use of `chmod` should be done using +x for instead of 777.